### PR TITLE
Useless MJSON_IMPLEMENT_STRTOD

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ int main(void) {
 # Build options
 
 - `-D MJSON_ENABLE_PRINT=0` disable emitting functionality, default: enabled
-- `-D MJSON_IMPLEMENT_STRTOD=1` use own `strtod()`, default: stdlib is used
 - `-D MJSON_MAX_DEPTH=30` define max object depth, default: 20
 - `-D MJSON_ENABLE_BASE64=0` disable base64 parsing/printing, default: enabled
 - `-D MJSON_ENABLE_RPC=0` disable RPC functionality, default: enabled


### PR DESCRIPTION
The own strtod is now the default one and can't be disabled therefore is the define MJSON_IMPLEMENT_STRTOD useless