### PR TITLE
Correct formatting of doubles with trailing zeroes in integer part

### DIFF
--- a/src/mjson.c
+++ b/src/mjson.c
@@ -593,7 +593,7 @@ int mjson_print_dbl(mjson_print_fn_t fn, void *fnd, double d, int width) {
     n += addexp(buf + s + n, -e, '-');
     return fn(buf, s + n, fnd);
   } else {
-    for (i = 0, t = mul; d >= 1.0 && s + n < (int) sizeof(buf); i++) {
+    for (i = 0, t = mul; t >= 1.0 && s + n < (int) sizeof(buf); i++) {
       int ch = (int) (d / t);
       if (n > 0 || ch > 0) buf[s + n++] = (char) (ch + '0');
       d -= ch * t;


### PR DESCRIPTION
It looks like the condition for terminating the loop while outputting the integer part of the number was wrong.  It's terminating when the *value* (`d`) to print is not greater than 1.  For numbers like "600" this value is zero after the first pass to print out `6`.  Instead, use `t` which will decrease to 1 for all of the iterations printing digits and then the loop will terminate once it reaches 0.1.

Unlike the other print functions, `mjson_print_dbl` isn't public in *mjson.h*, and it does not appear to have unit test coverage.  While I haven't added such coverage in this fix, it is something that would be worth considering to add. 

Closes: #38 