### PR TITLE
mjson_merge delete key

### DIFF
--- a/src/mjson.h
+++ b/src/mjson.h
@@ -75,6 +75,7 @@ extern "C" {
 #define MJSON_TOK_TRUE 13
 #define MJSON_TOK_FALSE 14
 #define MJSON_TOK_NULL 15
+#define MJSON_TOK_DEL 16
 #define MJSON_TOK_ARRAY 91
 #define MJSON_TOK_OBJECT 123
 #define MJSON_TOK_IS_VALUE(t) ((t) > 10 && (t) < 20)


### PR DESCRIPTION
"del" keyword was added istead of "null" keyword in order to delete key in the JSON string.
some keys' value may be null in the JSON string.(i.e: { "key1": true, "key2": null } ) Current implementation doesn't cover "null" value.