### PR TITLE
JSON-RPC error messages

### DIFF
--- a/src/mjson.h
+++ b/src/mjson.h
@@ -208,10 +208,17 @@ extern void jsonrpc_list(struct jsonrpc_request *r);
 #define jsonrpc_process(buf, len, fn, fnd, ud) \
   jsonrpc_ctx_process(&jsonrpc_default_context, (buf), (len), (fn), (fnd), (ud))
 
-#define JSONRPC_ERROR_INVALID -32700    /* Invalid JSON was received */
-#define JSONRPC_ERROR_NOT_FOUND -32601  /* The method does not exist */
-#define JSONRPC_ERROR_BAD_PARAMS -32602 /* Invalid params passed */
-#define JSONRPC_ERROR_INTERNAL -32603   /* Internal JSON-RPC error */
+#define JSONRPC_ERROR_PARSE -32700            /* Invalid JSON was received */
+#define JSONRPC_ERROR_BAD_REQUEST -32600      /* The JSON sent is not a valid Request object */
+#define JSONRPC_ERROR_METHOD_NOT_FOUND -32601 /* The method does not exist or is not available*/
+#define JSONRPC_ERROR_BAD_PARAMS -32602       /* Invalid method parameter(s) */
+#define JSONRPC_ERROR_INTERNAL -32603         /* Internal JSON-RPC error */
+
+#define JSONRPC_ERROR_MSG_PARSE "Parse error"
+#define JSONRPC_ERROR_MSG_BAD_REQUEST "Invalid Request"
+#define JSONRPC_ERROR_MSG_METHOD_NOT_FOUND "Method not found"
+#define JSONRPC_ERROR_MSG_BAD_PARAMS "Invalid params"
+#define JSONRPC_ERROR_MSG_INTERNAL "Internal error"
 
 #endif  // MJSON_ENABLE_RPC
 #ifdef __cplusplus


### PR DESCRIPTION
These changes try to align the error messages generated in the mjson jsonrpc handler with the error messages in the [JSON-RPC 2.0 Specification](https://www.jsonrpc.org/specification). An example of such behavior is seen in #60.

Additionally, while writing tests for this new functionality using the existing test pattern, I observed a situation where some tests for the jsonrpc functionality would pass even when they contained an intentional error. When there were two consecutive tests that produced the same output string, the second test would not fail (when it should have) because the call to `ASSERT` would compare strings using the output string from the previous unit test without first checking the length. Since the length is set to zero before each test, it should be tested using `ASSERT` before performing a string comparison.

