### PR TITLE
Added conditional include of sdk provided alloca for nrf52 boards

### DIFF
--- a/src/mjson.c
+++ b/src/mjson.c
@@ -24,6 +24,10 @@
 
 #include "mjson.h"
 
+#if defined(NRF52)
+#include <sdk_alloca.h>
+#endif
+
 #if defined(_MSC_VER)
 #define alloca(x) _alloca(x)
 #endif


### PR DESCRIPTION
On Nordic nRF52 boards there is no standard implementation of alloca, so we need to include it from <sdk_alloca.h> that is provided in the nRF52 SDK. On these projects you typically also define the NRF52 macro that is used in the SDK. This way we can check if we are running on the SDK and can include the missing alloca() implementation.