### PR TITLE
make sure to include alloca.h before using it

### DIFF
--- a/src/mjson.c
+++ b/src/mjson.c
@@ -26,6 +26,8 @@
 
 #if defined(_MSC_VER)
 #define alloca(x) _alloca(x)
+#else
+#include <alloca.h>
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER < 1700


### PR DESCRIPTION
We have to include `alloca.h` if we want to use the `alloca()` function.

```C
build/pkg/mjson/src/mjson.c: In function ‘mjson_merge’:
build/pkg/mjson/src/mjson.c:823:27: error: implicit declaration of function ‘alloca’ [-Werror=implicit-function-declaration]
     char *path = (char *) alloca((size_t) klen + 1);
                           ^
cc1: all warnings being treated as errors
```