### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/mjson
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/mjson

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,3 @@
+# ClusterFuzzLite set up
+
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -eu
+# Copy all fuzzer executables to $OUT/
+$CC $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/mjson/.clusterfuzzlite/mjson_fuzzer.c \
+  -o $OUT/mjson_fuzzer \
+  $SRC/mjson/src/mjson.c -I$SRC/mjson/src/

--- a/.clusterfuzzlite/mjson_fuzzer.c
+++ b/.clusterfuzzlite/mjson_fuzzer.c
@@ -1,0 +1,22 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <mjson.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size == 0) {
+    return 0;
+  }
+  uint8_t decider = data[0];
+  size -= 1;
+  data++;
+
+  if ((decider % 2) == 0) {
+    mjson((const char *)data, size, NULL, NULL);
+  } else {
+    mjson_find((const char *)data, size, "$.a", NULL, NULL);
+  }
+
+  return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets `mjson` and `mjson_find`, and currently set the timeout of CFLite to 100 seconds. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.

For a quick way of reproducing the fuzzing set up by way of OSS-Fuzz (which is the infra ClusterFuzzLite will use):

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/mjson mjson
cd mjson
git checkout clusterfuzz-lite-integration 

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD mjson_fuzzer -- -max_total_time=10
```